### PR TITLE
Fix uncaught "resource closed" in http server instrumentation

### DIFF
--- a/hack/bundle-opentelemetry.ts
+++ b/hack/bundle-opentelemetry.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-run --allow-read --allow-write=. --allow-env
+#!/usr/bin/env -S deno run --allow-run --allow-read --allow-write=. --allow-env --allow-sys
 
 // pass --refresh-yarn to force rerunning yarn on the opentelemetry packages
 

--- a/hack/bundle-opentelemetry.ts
+++ b/hack/bundle-opentelemetry.ts
@@ -2,11 +2,11 @@
 
 // pass --refresh-yarn to force rerunning yarn on the opentelemetry packages
 
-import { rollup, Plugin } from 'npm:rollup';
-import { nodeResolve } from 'npm:@rollup/plugin-node-resolve';
-import commonjs from 'npm:@rollup/plugin-commonjs';
-import sourcemaps from 'npm:rollup-plugin-sourcemaps';
-import cleanup from 'npm:rollup-plugin-cleanup';
+import { rollup, Plugin } from 'npm:rollup@4.17.2';
+import { nodeResolve } from 'npm:@rollup/plugin-node-resolve@15.2.3';
+import commonjs from 'npm:@rollup/plugin-commonjs@25.0.7';
+import sourcemaps from 'npm:rollup-plugin-sourcemaps@0.6.3';
+import cleanup from 'npm:rollup-plugin-cleanup@3.2.1';
 import dts from 'npm:rollup-plugin-dts@4.2.3';
 // import { terser } from "npm:rollup-plugin-terser";
 

--- a/hack/bundle-opentelemetry.ts
+++ b/hack/bundle-opentelemetry.ts
@@ -1,8 +1,7 @@
-#!/usr/bin/env -S deno run --allow-run --allow-read --allow-write=. --allow-env --allow-sys
+#!/usr/bin/env -S deno run --allow-run --allow-read --allow-write=. --allow-env --allow-sys --allow-ffi
 
 // pass --refresh-yarn to force rerunning yarn on the opentelemetry packages
 
-import 'npm:@rollup/rollup-linux-x64-gnu@4.17.2';
 import { rollup, Plugin } from 'npm:rollup@4.17.2';
 import { nodeResolve } from 'npm:@rollup/plugin-node-resolve@15.2.3';
 import commonjs from 'npm:@rollup/plugin-commonjs@25.0.7';

--- a/hack/bundle-opentelemetry.ts
+++ b/hack/bundle-opentelemetry.ts
@@ -2,6 +2,7 @@
 
 // pass --refresh-yarn to force rerunning yarn on the opentelemetry packages
 
+import 'npm:@rollup/rollup-linux-x64-gnu@4.17.2';
 import { rollup, Plugin } from 'npm:rollup@4.17.2';
 import { nodeResolve } from 'npm:@rollup/plugin-node-resolve@15.2.3';
 import commonjs from 'npm:@rollup/plugin-commonjs@25.0.7';

--- a/instrumentation/http-server.ts
+++ b/instrumentation/http-server.ts
@@ -88,6 +88,9 @@ export function httpTracer(inner: Deno.ServeHandler, opts?: {
         const respSnoop = snoopStream(resp.body);
         respSnoop.finalSize.then(size => {
           serverSpan.setAttribute(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, size);
+        }).catch(err => {
+          serverSpan.recordException(err);
+          console.error(`pipeTo failed: ${err.message ?? err}`);
         }).finally(() => {
           inflightMetric.add(-1, reqMetricAttrs);
           serverSpan.end();

--- a/instrumentation/http-server.ts
+++ b/instrumentation/http-server.ts
@@ -89,8 +89,8 @@ export function httpTracer(inner: Deno.ServeHandler, opts?: {
         respSnoop.finalSize.then(size => {
           serverSpan.setAttribute(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, size);
         }).catch(err => {
+          // NOTE: err can be "resource closed" when the client walks away mid-response.
           serverSpan.recordException(err);
-          console.error(`pipeTo failed: ${err.message ?? err}`);
         }).finally(() => {
           inflightMetric.add(-1, reqMetricAttrs);
           serverSpan.end();

--- a/instrumentation/http-server.ts
+++ b/instrumentation/http-server.ts
@@ -102,6 +102,7 @@ export function httpTracer(inner: Deno.ServeHandler, opts?: {
         serverSpan.recordException(err);
         serverSpan.end();
         inflightMetric.add(-1, reqMetricAttrs);
+        console.error('httpTracer Error:', err);
         throw err;
       } finally {
         durationMetric.record(performance.now() - d0, reqMetricAttrs, ctx);

--- a/instrumentation/http-server.ts
+++ b/instrumentation/http-server.ts
@@ -102,7 +102,6 @@ export function httpTracer(inner: Deno.ServeHandler, opts?: {
         serverSpan.recordException(err);
         serverSpan.end();
         inflightMetric.add(-1, reqMetricAttrs);
-        console.error('httpTracer Error:', err);
         throw err;
       } finally {
         durationMetric.record(performance.now() - d0, reqMetricAttrs, ctx);


### PR DESCRIPTION
Fixes a program crash when the client cancels its request after we begin responding and before the end of our response stream.

Related to: 

* https://github.com/denoland/deno/issues/23058
* `error: Uncaught (in promise) "resource closed"`