### PR TITLE
Update opentelemetry-js: 1.15.2 -> 1.18.0

### DIFF
--- a/hack/bundle-opentelemetry.ts
+++ b/hack/bundle-opentelemetry.ts
@@ -256,7 +256,7 @@ for (const mod of packagePaths) {
 
 console.error(`Running tsc build...`);
 {
-  const tsc = new Deno.Command('hack/opentelemetry-js/node_modules/.bin/tsc', {
+  const tsc = new Deno.Command('node_modules/.bin/tsc', {
     args: [ '--build', 'tsconfig.esnext.deno.json' ],
     cwd: 'hack/opentelemetry-js',
     stdout: 'inherit',

--- a/hack/bundle-opentelemetry.ts
+++ b/hack/bundle-opentelemetry.ts
@@ -1,102 +1,28 @@
 #!/usr/bin/env -S deno run --allow-run --allow-read --allow-write=. --allow-env --allow-sys --allow-ffi
 
-// pass --refresh-yarn to force rerunning yarn on the opentelemetry packages
-
 import { rollup, Plugin } from 'npm:rollup@4.17.2';
 import { nodeResolve } from 'npm:@rollup/plugin-node-resolve@15.2.3';
 import commonjs from 'npm:@rollup/plugin-commonjs@25.0.7';
 import sourcemaps from 'npm:rollup-plugin-sourcemaps@0.6.3';
 import cleanup from 'npm:rollup-plugin-cleanup@3.2.1';
 import dts from 'npm:rollup-plugin-dts@4.2.3';
-// import { terser } from "npm:rollup-plugin-terser";
 
-// import magicString from 'npm:rollup-plugin-magic-string'
-
-
-// import MagicStringMod from 'npm:magic-string';
-// const MagicString = MagicStringMod as unknown as MagicStringMod.default;
-// import fs from 'node:fs'
-// import path from 'node:path'
-// function escape(str: string) {
-//     return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
-// }
-// // Figures out where the correct relative path should
-// // based on the output directory and the appendPath
-// function rollupOutputDir(opts, appendPath) {
-//     let dir = ''
-//     if (opts.file) {
-//         dir = path.dirname(opts.file)
-//     }
-//     else if (opts.dir) {
-//         dir = path.dirname(opts.dir)
-//     }
-//     return path.relative(dir, appendPath)
-// }
-
-// const patternImport = new RegExp(/import(?:["'\s]*([\w*${}\n\r\t, ]+)from\s*)?["'\s]["'\s](.*[@\w_-]+)["'\s].*;$/, 'mg')
-// const rewritePlugin: Plugin = {
-//     name: 'rewriteImports',
-//     renderChunk(code, info, opts) {
-//         // get the location of the output directory
-//         const magicString = new MagicString(code);
-//         let hasReplacements = false;
-//         let match: RegExpMatchArray | null = null;
-//         function replaceImport() {
-//             let newImport = '';
-//             if (match![2].startsWith('@opentelemetry/')) {
-//               newImport = match![2].split('/')[1] + '.js';
-//             }
-//             if (newImport) {
-//               hasReplacements = true
-//               const start = match!.index!
-//               const end = start + match![0].length
-//               magicString.overwrite(start, end, newImport)
-//             }
-//         }
-//         while (match = patternImport.exec(code)) {
-//           replaceImport()
-//         }
-//         if (!hasReplacements) return null
-//         const result = { code: magicString.toString() }
-//         return result
-//     }
-// };
-
-export async function buildModuleWithRollup(directory: string, modName: string, external: string[]) {
+async function buildModuleWithRollup(directory: string, modName: string, external: string[]) {
 
   const mainFile = await Deno.readTextFile(directory+'/build/esnext/index.js');
   const licenseComment = mainFile.startsWith('/*') ? mainFile.slice(0, mainFile.indexOf('*/')+3) : '';
 
   const bundle = await rollup({
-    // input: fromFileUrl(inputUrl),
     input: directory+'/build/esnext/index.js',
     external,
     plugins: [
       sourcemaps(),
       nodeResolve({
         // extensions : [".js",".jsx"],
-        // resolveOnly: module => {console.log({module});return true},
+        // resolveOnly: module => {console.error({module});return true},
       }),
       commonjs(),
       cleanup(),
-      // terser(),
-      // magicString({
-      //   magic(code: string, id, string) {
-      //     const patternImport = new RegExp(/import(?:["'\s]*([\w*${}\n\r\t, ]+)from\s*)?["'\s]["'\s](.*[@\w_-]+)["'\s].*;$/, 'mg')
-      //     let match: RegExpMatchArray | null = null;
-      //     while (match = patternImport.exec(code)) {
-      //       let newImport = '';
-      //       if (match[2].startsWith('@opentelemetry/')) {
-      //         newImport = './' + match[2].split('/')[1] + '.js';
-      //       }
-      //       if (newImport) {
-      //         const start = match.index! + match[0].indexOf(match[2]);
-      //         const end = start + match[2].length
-      //         string.overwrite(start, end, newImport)
-      //       }
-      //     }
-      //   },
-      // }),
     ],
   }).then(x => x.generate({
     format: 'es',
@@ -139,7 +65,7 @@ export async function buildModuleWithRollup(directory: string, modName: string, 
     const patternImport = /(?:import|export)(?:["'\s]*([\w*${}\n\r\t, ]+)from\s*)?["'\s]["'\s](.*[@\w_-]+)["'\s].*;$/m;
     const patternImportG = new RegExp(patternImport, 'mg');
     text = text.replaceAll(patternImportG, matchText => {
-      // console.log({matchText})
+      // console.error({matchText})
       let match = matchText.match(patternImport);
       if (!match) throw new Error('bug');
       let newImport = '';
@@ -151,7 +77,7 @@ export async function buildModuleWithRollup(directory: string, modName: string, 
       } else if (['shimmer'].includes(match[2])) {
         newImport = `https://esm.sh/${match[2]}`;
       } else {
-        console.log('Unhandled import:', match[2]);
+        console.error('Unhandled import:', match[2]);
       }
       if (!newImport) return match[0];
       const start = match.index! + match[0].lastIndexOf(match[2]);
@@ -180,35 +106,11 @@ export async function buildModuleWithRollup(directory: string, modName: string, 
   }
 }
 
-const modules = [
-  'hack/opentelemetry-js/api',
-  'hack/opentelemetry-js/packages/opentelemetry-core',
-  // 'hack/opentelemetry-js/packages/opentelemetry-context-async-hooks',
-  // 'hack/opentelemetry-js/packages/opentelemetry-context-zone-peer-dep',
-  // 'hack/opentelemetry-js/packages/opentelemetry-context-zone',
-  'hack/opentelemetry-js/packages/opentelemetry-semantic-conventions',
-  'hack/opentelemetry-js/packages/opentelemetry-resources',
-  'hack/opentelemetry-js/packages/opentelemetry-propagator-b3',
-  'hack/opentelemetry-js/packages/opentelemetry-sdk-trace-base',
-  // 'hack/opentelemetry-js/packages/opentelemetry-sdk-trace-web',
-  'hack/opentelemetry-js/packages/sdk-metrics',
-  'hack/opentelemetry-js/experimental/packages/api-events',
-  'hack/opentelemetry-js/experimental/packages/api-logs',
-  'hack/opentelemetry-js/experimental/packages/otlp-exporter-base',
-  'hack/opentelemetry-js/experimental/packages/otlp-transformer',
-  // 'hack/opentelemetry-js/experimental/packages/exporter-trace-otlp-http',
-  // 'hack/opentelemetry-js/experimental/packages/opentelemetry-browser-detector',
-  'hack/opentelemetry-js/experimental/packages/opentelemetry-exporter-metrics-otlp-http',
-  'hack/opentelemetry-js/experimental/packages/opentelemetry-instrumentation',
-  // 'hack/opentelemetry-js/experimental/packages/opentelemetry-instrumentation-fetch',
-  // 'hack/opentelemetry-js/experimental/packages/opentelemetry-instrumentation-http',
-  // 'hack/opentelemetry-js/experimental/packages/opentelemetry-instrumentation-xml-http-request',
-  'hack/opentelemetry-js/experimental/packages/sdk-logs',
-];
+console.error(`Patching opentelemetry-js installation to remove NodeJSisms...`);
 
 await new Deno.Command('rm', {
-  args: ['-r', 'hack/opentelemetry-js/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform'],
-  stdin: 'null',
+  args: ['-rf', 'experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform'],
+  cwd: 'hack/opentelemetry-js',
   stdout: 'inherit',
   stderr: 'inherit',
 }).output();
@@ -288,98 +190,99 @@ await Deno.writeTextFile('hack/opentelemetry-js/tsconfig.base.json',
   await Deno.readTextFile('hack/opentelemetry-js/tsconfig.base.json').then(text => text
     .replace('es2017', 'es2021'))); // target
 
+// from upstream tsconfig.esnext.json
+const packagePaths = [
+  "api",
+  // "packages/opentelemetry-context-zone",
+  // "packages/opentelemetry-context-zone-peer-dep",
+  "packages/opentelemetry-core",
+  // "packages/opentelemetry-exporter-zipkin",
+  "packages/opentelemetry-propagator-b3",
+  "packages/opentelemetry-propagator-jaeger",
+  "packages/opentelemetry-resources",
+  "packages/opentelemetry-sdk-trace-base",
+  // "packages/opentelemetry-sdk-trace-web",
+  "packages/opentelemetry-semantic-conventions",
+  // "packages/propagator-aws-xray",
+  "packages/sdk-metrics",
+  "experimental/packages/api-events",
+  "experimental/packages/api-logs",
+  // "experimental/packages/exporter-logs-otlp-http",
+  // "experimental/packages/exporter-logs-otlp-proto",
+  // "experimental/packages/exporter-trace-otlp-http",
+  // "experimental/packages/exporter-trace-otlp-proto",
+  // "experimental/packages/opentelemetry-browser-detector",
+  "experimental/packages/opentelemetry-exporter-metrics-otlp-http",
+  // "experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
+  "experimental/packages/opentelemetry-instrumentation",
+  // "experimental/packages/opentelemetry-instrumentation-fetch",
+  // "experimental/packages/opentelemetry-instrumentation-xml-http-request",
+  "experimental/packages/otlp-exporter-base",
+  // "experimental/packages/otlp-proto-exporter-base",
+  "experimental/packages/otlp-transformer",
+  "experimental/packages/sdk-logs",
+]
+
+console.error(`Writing new tsconfig...`);
 // create tsconfig project with the subset of modules we care about
 await Deno.writeTextFile('hack/opentelemetry-js/tsconfig.esnext.deno.json', JSON.stringify({
   "extends": "./tsconfig.base.esnext.json",
   "files": [],
-  "references": [
-    { "path": "api/tsconfig.esnext.json" },
-    { "path": "experimental/packages/api-events/tsconfig.esnext.json" },
-    { "path": "experimental/packages/api-logs/tsconfig.esnext.json" },
-    // { "path": "experimental/packages/exporter-logs-otlp-http/tsconfig.esnext.json" },
-    // { "path": "experimental/packages/exporter-logs-otlp-proto/tsconfig.esnext.json" },
-    // { "path": "experimental/packages/exporter-trace-otlp-http/tsconfig.esnext.json" },
-    // { "path": "experimental/packages/exporter-trace-otlp-proto/tsconfig.esnext.json" },
-    // { "path": "experimental/packages/opentelemetry-browser-detector/tsconfig.esnext.json" },
-    { "path": "experimental/packages/opentelemetry-exporter-metrics-otlp-http/tsconfig.esnext.json" },
-    // { "path": "experimental/packages/opentelemetry-exporter-metrics-otlp-proto/tsconfig.esnext.json" },
-    { "path": "experimental/packages/opentelemetry-instrumentation/tsconfig.esnext.json" },
-    // { "path": "experimental/packages/opentelemetry-instrumentation-fetch/tsconfig.esnext.json" },
-    // { "path": "experimental/packages/opentelemetry-instrumentation-xml-http-request/tsconfig.esnext.json" },
-    { "path": "experimental/packages/otlp-exporter-base/tsconfig.esnext.json" },
-    // { "path": "experimental/packages/otlp-proto-exporter-base/tsconfig.esnext.json" },
-    { "path": "experimental/packages/otlp-transformer/tsconfig.esnext.json" },
-    { "path": "experimental/packages/sdk-logs/tsconfig.esnext.json" },
-    // { "path": "packages/opentelemetry-context-zone/tsconfig.esnext.json" },
-    // { "path": "packages/opentelemetry-context-zone-peer-dep/tsconfig.esnext.json" },
-    { "path": "packages/opentelemetry-core/tsconfig.esnext.json" },
-    // { "path": "packages/opentelemetry-exporter-zipkin/tsconfig.esnext.json" },
-    { "path": "packages/opentelemetry-propagator-b3/tsconfig.esnext.json" },
-    { "path": "packages/opentelemetry-propagator-jaeger/tsconfig.esnext.json" },
-    { "path": "packages/opentelemetry-resources/tsconfig.esnext.json" },
-    { "path": "packages/opentelemetry-sdk-trace-base/tsconfig.esnext.json" },
-    // { "path": "packages/opentelemetry-sdk-trace-web/tsconfig.esnext.json" },
-    { "path": "packages/opentelemetry-semantic-conventions/tsconfig.esnext.json" },
-    // { "path": "packages/propagator-aws-xray/tsconfig.esnext.json" },
-    { "path": "packages/sdk-metrics/tsconfig.esnext.json" },
-  ],
+  "references": packagePaths.map(x => ({
+    "path": `${x}/tsconfig.esnext.json`,
+  })),
 }, null, 2));
 
-async function npmInstall(directory: string) {
-  // if (!Deno.args.includes('--refresh-yarn')) {
-  //   if (await Deno.stat(directory+'/node_modules').then(() => true, () => false)) return;
-  // }
+console.error(`Running npm install...`);
+{
   const npm = new Deno.Command('npm', {
     args: ['install', /*'--production',*/ '--ignore-scripts'],
-    cwd: directory,
+    cwd: 'hack/opentelemetry-js',
     stdout: 'inherit',
     stderr: 'inherit',
   });
   const npmOut = await npm.output();
-  // if (npmOut.stdout.byteLength > 0) {
-  //   console.log(new TextDecoder().decode(npmOut.stdout));
-  // }
-  if (!npmOut.success) throw new Error(`npm failed on ${directory}`);
+  if (!npmOut.success) throw new Error(`npm failed on hack/opentelemetry-js`);
 }
 
-await npmInstall('hack/opentelemetry-js');
-
-for (const mod of modules) {
+console.error(`Adding version.ts to each package...`);
+for (const mod of packagePaths) {
+  const path = `hack/opentelemetry-js/${mod}`;
   const {
     version,
-  } = JSON.parse(await Deno.readTextFile(mod+'/package.json'));
-  await Deno.writeTextFile(mod+'/src/version.ts', `export const VERSION = ${JSON.stringify(version)};`);
+  } = JSON.parse(await Deno.readTextFile(path+'/package.json'));
+  await Deno.writeTextFile(path+'/src/version.ts', `export const VERSION = ${JSON.stringify(version)};`);
 }
 
-const tsc = new Deno.Command('hack/opentelemetry-js/node_modules/.bin/tsc', {
-  args: [
-    '--build', 'hack/opentelemetry-js/tsconfig.esnext.deno.json',
-    // '--project', mod+'/tsconfig.esnext.json',
-    // '--target', 'es2021',
-    // '--module', 'es2020',
-    // '--lib', TODO: can we provide deno's lib somehow?
-  ],
-});
-const tscOut = await tsc.output();
-console.log(new TextDecoder().decode(tscOut.stdout));
-if (!tscOut.success) throw new Error(`TSC failed :(`);
+console.error(`Running tsc build...`);
+{
+  const tsc = new Deno.Command('hack/opentelemetry-js/node_modules/.bin/tsc', {
+    args: [ '--build', 'tsconfig.esnext.deno.json' ],
+    cwd: 'hack/opentelemetry-js',
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  const tscOut = await tsc.output();
+  if (!tscOut.success) throw new Error(`TSC failed :(`);
+}
 
-// import ts from "npm:typescript";
-
-for (const mod of modules) {
-  console.log('---------------')
-  console.log(mod);
-  console.log();
+console.error(`Bundling packages with rollup...`);
+for (const mod of packagePaths) {
+  const path = `hack/opentelemetry-js/${mod}`;
 
   const {
     name,
     dependencies,
     peerDependencies,
-  } = JSON.parse(await Deno.readTextFile(mod+'/package.json'));
+  } = JSON.parse(await Deno.readTextFile(path+'/package.json'));
   const modName = name.split('/')[1];
+  console.error('  Bundling', name);
 
-  await buildModuleWithRollup(mod, modName, [
+  await buildModuleWithRollup(path, modName, [
     ...Object.keys(dependencies ?? {}),
     ...Object.keys(peerDependencies ?? {}),
   ]);
+
 }
+console.error('Bundled', packagePaths.length, 'packages.');
+console.error();

--- a/opentelemetry/api.d.ts
+++ b/opentelemetry/api.d.ts
@@ -866,6 +866,17 @@ interface BatchObservableResult<AttributesTypes extends MetricAttributes = Metri
 }
 
 /**
+ * Advisory options influencing aggregation configuration parameters.
+ * @experimental
+ */
+interface MetricAdvice {
+	/**
+	* Hint the explicit bucket boundaries for SDK if the metric is been
+	* aggregated with a HistogramAggregator.
+	*/
+	explicitBucketBoundaries?: number[];
+}
+/**
  * Options needed for metric creation
  */
 interface MetricOptions {
@@ -884,6 +895,11 @@ interface MetricOptions {
 	* @default {@link ValueType.DOUBLE}
 	*/
 	valueType?: ValueType;
+	/**
+	* The advice influencing aggregation configuration parameters.
+	* @experimental
+	*/
+	advice?: MetricAdvice;
 }
 /** The Type of value. It describes how the data is reported. */
 declare enum ValueType {
@@ -1475,4 +1491,4 @@ declare const _default: {
 };
 //# sourceMappingURL=index.d.ts.map
 
-export { AttributeValue, Attributes, Baggage, BaggageEntry, BaggageEntryMetadata, BatchObservableCallback, BatchObservableResult, ComponentLoggerOptions, Context, ContextAPI, ContextManager, Counter, DiagAPI, DiagConsoleLogger, DiagLogFunction, DiagLogLevel, DiagLogger, DiagLoggerOptions, Exception, Histogram, HrTime, INVALID_SPANID, INVALID_SPAN_CONTEXT, INVALID_TRACEID, Link, Meter, MeterOptions, MeterProvider, MetricAttributeValue, MetricAttributes, MetricOptions, MetricsAPI, Observable, ObservableCallback, ObservableCounter, ObservableGauge, ObservableResult, ObservableUpDownCounter, PropagationAPI, ProxyTracer, ProxyTracerProvider, ROOT_CONTEXT, Sampler, SamplingDecision, SamplingResult, Span, SpanAttributeValue, SpanAttributes, SpanContext, SpanKind, SpanOptions, SpanStatus, SpanStatusCode, TextMapGetter, TextMapPropagator, TextMapSetter, TimeInput, TraceAPI, TraceFlags, TraceState, Tracer, TracerDelegator, TracerOptions, TracerProvider, UpDownCounter, ValueType, baggageEntryMetadataFromString, context, createContextKey, createNoopMeter, createTraceState, _default as default, defaultTextMapGetter, defaultTextMapSetter, diag, isSpanContextValid, isValidSpanId, isValidTraceId, metrics, propagation, trace };
+export { AttributeValue, Attributes, Baggage, BaggageEntry, BaggageEntryMetadata, BatchObservableCallback, BatchObservableResult, ComponentLoggerOptions, Context, ContextAPI, ContextManager, Counter, DiagAPI, DiagConsoleLogger, DiagLogFunction, DiagLogLevel, DiagLogger, DiagLoggerOptions, Exception, Histogram, HrTime, INVALID_SPANID, INVALID_SPAN_CONTEXT, INVALID_TRACEID, Link, Meter, MeterOptions, MeterProvider, MetricAdvice, MetricAttributeValue, MetricAttributes, MetricOptions, MetricsAPI, Observable, ObservableCallback, ObservableCounter, ObservableGauge, ObservableResult, ObservableUpDownCounter, PropagationAPI, ProxyTracer, ProxyTracerProvider, ROOT_CONTEXT, Sampler, SamplingDecision, SamplingResult, Span, SpanAttributeValue, SpanAttributes, SpanContext, SpanKind, SpanOptions, SpanStatus, SpanStatusCode, TextMapGetter, TextMapPropagator, TextMapSetter, TimeInput, TraceAPI, TraceFlags, TraceState, Tracer, TracerDelegator, TracerOptions, TracerProvider, UpDownCounter, ValueType, baggageEntryMetadataFromString, context, createContextKey, createNoopMeter, createTraceState, _default as default, defaultTextMapGetter, defaultTextMapSetter, diag, isSpanContextValid, isValidSpanId, isValidTraceId, metrics, propagation, trace };

--- a/opentelemetry/api.js
+++ b/opentelemetry/api.js
@@ -17,7 +17,7 @@
 
 const _globalThis = typeof globalThis === 'object' ? globalThis : global;
 
-const VERSION = "1.4.1";
+const VERSION = "1.7.0";
 
 const re = /^(\d+)\.(\d+)\.(\d+)(-(.+))?$/;
 function _makeCompatibilityCheck(ownVersion) {

--- a/opentelemetry/core.d.ts
+++ b/opentelemetry/core.d.ts
@@ -201,8 +201,6 @@ declare enum ExportResultCode {
 	FAILED = 1
 }
 
-declare const VERSION = "1.15.2";
-
 declare type ParsedBaggageKeyValue = {
 	key: string;
 	value: string;
@@ -364,7 +362,7 @@ declare const SDK_INFO: {
 	[x: string]: string;
 };
 
-declare function unrefTimer(timer: number): void;
+declare function unrefTimer(timer: any): void;
 
 /** Configuration object for composite propagator */
 interface CompositePropagatorConfig {
@@ -593,6 +591,8 @@ declare class BindOnceFuture<R, This = unknown, T extends (this: This, ...args: 
 	get promise(): Promise<R>;
 	call(...args: Parameters<T>): Promise<R>;
 }
+
+declare const VERSION = "1.18.0";
 
 interface Exporter<T> {
 	export(arg: T, resultCallback: (result: ExportResult) => void): void;

--- a/opentelemetry/core.js
+++ b/opentelemetry/core.js
@@ -523,7 +523,7 @@ function getIdGenerator(bytes) {
 
 const otperformance = performance;
 
-const VERSION$1 = "1.15.2";
+const VERSION$1 = "1.18.0";
 
 const SDK_INFO = {
 	[SemanticResourceAttributes.TELEMETRY_SDK_NAME]: 'opentelemetry',

--- a/opentelemetry/otlp-transformer.d.ts
+++ b/opentelemetry/otlp-transformer.d.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { HrTime } from './api.d.ts';
 import { ReadableSpan } from './sdk-trace-base.d.ts';
 import { ResourceMetrics } from './sdk-metrics.d.ts';
 import { ReadableLogRecord } from './sdk-logs.d.ts';
@@ -63,6 +64,31 @@ interface IKeyValueList {
 	/** KeyValueList values */
 	values: IKeyValue[];
 }
+interface LongBits {
+	low: number;
+	high: number;
+}
+declare type Fixed64 = LongBits | string | number;
+interface OtlpEncodingOptions {
+	/** Convert trace and span IDs to hex strings. */
+	useHex?: boolean;
+	/** Convert HrTime to 2 part 64 bit values. */
+	useLongBits?: boolean;
+}
+
+declare function hrTimeToNanos(hrTime: HrTime): bigint;
+declare function toLongBits(value: bigint): LongBits;
+declare function encodeAsLongBits(hrTime: HrTime): LongBits;
+declare function encodeAsString(hrTime: HrTime): string;
+declare type HrTimeEncodeFunction = (hrTime: HrTime) => Fixed64;
+declare type SpanContextEncodeFunction = (spanContext: string) => string;
+declare type OptionalSpanContextEncodeFunction = (spanContext: string | undefined) => string | undefined;
+interface Encoder {
+	encodeHrTime: HrTimeEncodeFunction;
+	encodeSpanContext: SpanContextEncodeFunction;
+	encodeOptionalSpanContext: OptionalSpanContextEncodeFunction;
+}
+declare function getOtlpEncoder(options?: OtlpEncodingOptions): Encoder;
 
 /** Properties of a Resource. */
 interface IResource {
@@ -162,9 +188,9 @@ interface INumberDataPoint {
 	/** NumberDataPoint attributes */
 	attributes: IKeyValue[];
 	/** NumberDataPoint startTimeUnixNano */
-	startTimeUnixNano?: number;
+	startTimeUnixNano?: Fixed64;
 	/** NumberDataPoint timeUnixNano */
-	timeUnixNano?: number;
+	timeUnixNano?: Fixed64;
 	/** NumberDataPoint asDouble */
 	asDouble?: number | null;
 	/** NumberDataPoint asInt */
@@ -179,9 +205,9 @@ interface IHistogramDataPoint {
 	/** HistogramDataPoint attributes */
 	attributes?: IKeyValue[];
 	/** HistogramDataPoint startTimeUnixNano */
-	startTimeUnixNano?: number;
+	startTimeUnixNano?: Fixed64;
 	/** HistogramDataPoint timeUnixNano */
-	timeUnixNano?: number;
+	timeUnixNano?: Fixed64;
 	/** HistogramDataPoint count */
 	count?: number;
 	/** HistogramDataPoint sum */
@@ -204,9 +230,9 @@ interface IExponentialHistogramDataPoint {
 	/** ExponentialHistogramDataPoint attributes */
 	attributes?: IKeyValue[];
 	/** ExponentialHistogramDataPoint startTimeUnixNano */
-	startTimeUnixNano?: number;
+	startTimeUnixNano?: Fixed64;
 	/** ExponentialHistogramDataPoint timeUnixNano */
-	timeUnixNano?: number;
+	timeUnixNano?: Fixed64;
 	/** ExponentialHistogramDataPoint count */
 	count?: number;
 	/** ExponentialHistogramDataPoint sum */
@@ -392,9 +418,9 @@ interface ISpan {
 	/** Span kind */
 	kind: ESpanKind;
 	/** Span startTimeUnixNano */
-	startTimeUnixNano: number;
+	startTimeUnixNano: Fixed64;
 	/** Span endTimeUnixNano */
-	endTimeUnixNano: number;
+	endTimeUnixNano: Fixed64;
 	/** Span attributes */
 	attributes: IKeyValue[];
 	/** Span droppedAttributesCount */
@@ -459,7 +485,7 @@ declare enum EStatusCode {
 /** Properties of an Event. */
 interface IEvent {
 	/** Event timeUnixNano */
-	timeUnixNano: number;
+	timeUnixNano: Fixed64;
 	/** Event name */
 	name: string;
 	/** Event attributes */
@@ -517,9 +543,9 @@ interface IScopeLogs {
 /** Properties of a LogRecord. */
 interface ILogRecord {
 	/** LogRecord timeUnixNano */
-	timeUnixNano: number;
+	timeUnixNano: Fixed64;
 	/** LogRecord observedTimeUnixNano */
-	observedTimeUnixNano: number;
+	observedTimeUnixNano: Fixed64;
 	/** LogRecord severityNumber */
 	severityNumber?: ESeverityNumber;
 	/** LogRecord severityText */
@@ -569,10 +595,10 @@ declare enum ESeverityNumber {
 	SEVERITY_NUMBER_FATAL4 = 24
 }
 
-declare function createExportTraceServiceRequest(spans: ReadableSpan[], useHex?: boolean): IExportTraceServiceRequest;
+declare function createExportTraceServiceRequest(spans: ReadableSpan[], options?: OtlpEncodingOptions): IExportTraceServiceRequest;
 
-declare function createExportMetricsServiceRequest(resourceMetrics: ResourceMetrics[]): IExportMetricsServiceRequest;
+declare function createExportMetricsServiceRequest(resourceMetrics: ResourceMetrics[], options?: OtlpEncodingOptions): IExportMetricsServiceRequest;
 
-declare function createExportLogsServiceRequest(logRecords: ReadableLogRecord[], useHex?: boolean): IExportLogsServiceRequest;
+declare function createExportLogsServiceRequest(logRecords: ReadableLogRecord[], options?: OtlpEncodingOptions): IExportLogsServiceRequest;
 
-export { EAggregationTemporality, ESeverityNumber, ESpanKind, EStatusCode, IAnyValue, IArrayValue, IBuckets, IEvent, IExemplar, IExponentialHistogram, IExponentialHistogramDataPoint, IExportLogsPartialSuccess, IExportLogsServiceRequest, IExportLogsServiceResponse, IExportMetricsPartialSuccess, IExportMetricsServiceRequest, IExportMetricsServiceResponse, IExportTracePartialSuccess, IExportTraceServiceRequest, IExportTraceServiceResponse, IGauge, IHistogram, IHistogramDataPoint, IInstrumentationScope, IKeyValue, IKeyValueList, ILink, ILogRecord, IMetric, INumberDataPoint, IResource, IResourceLogs, IResourceMetrics, IResourceSpans, IScopeLogs, IScopeMetrics, IScopeSpans, ISpan, IStatus, ISum, ISummary, ISummaryDataPoint, IValueAtQuantile, createExportLogsServiceRequest, createExportMetricsServiceRequest, createExportTraceServiceRequest };
+export { EAggregationTemporality, ESeverityNumber, ESpanKind, EStatusCode, Encoder, Fixed64, HrTimeEncodeFunction, IAnyValue, IArrayValue, IBuckets, IEvent, IExemplar, IExponentialHistogram, IExponentialHistogramDataPoint, IExportLogsPartialSuccess, IExportLogsServiceRequest, IExportLogsServiceResponse, IExportMetricsPartialSuccess, IExportMetricsServiceRequest, IExportMetricsServiceResponse, IExportTracePartialSuccess, IExportTraceServiceRequest, IExportTraceServiceResponse, IGauge, IHistogram, IHistogramDataPoint, IInstrumentationScope, IKeyValue, IKeyValueList, ILink, ILogRecord, IMetric, INumberDataPoint, IResource, IResourceLogs, IResourceMetrics, IResourceSpans, IScopeLogs, IScopeMetrics, IScopeSpans, ISpan, IStatus, ISum, ISummary, ISummaryDataPoint, IValueAtQuantile, LongBits, OptionalSpanContextEncodeFunction, OtlpEncodingOptions, SpanContextEncodeFunction, createExportLogsServiceRequest, createExportMetricsServiceRequest, createExportTraceServiceRequest, encodeAsLongBits, encodeAsString, getOtlpEncoder, hrTimeToNanos, toLongBits };

--- a/opentelemetry/propagator-jaeger.d.ts
+++ b/opentelemetry/propagator-jaeger.d.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TextMapPropagator, Context, TextMapSetter, TextMapGetter } from './api.d.ts';
+
+interface JaegerPropagatorConfig {
+	customTraceHeader?: string;
+	customBaggageHeaderPrefix?: string;
+}
+
+declare const UBER_TRACE_ID_HEADER = "uber-trace-id";
+declare const UBER_BAGGAGE_HEADER_PREFIX = "uberctx";
+/**
+ * Propagates {@link SpanContext} through Trace Context format propagation.
+ * {trace-id}:{span-id}:{parent-span-id}:{flags}
+ * {trace-id}
+ * 64-bit or 128-bit random number in base16 format.
+ * Can be variable length, shorter values are 0-padded on the left.
+ * Value of 0 is invalid.
+ * {span-id}
+ * 64-bit random number in base16 format.
+ * {parent-span-id}
+ * Set to 0 because this field is deprecated.
+ * {flags}
+ * One byte bitmap, as two hex digits.
+ * Inspired by jaeger-client-node project.
+ */
+declare class JaegerPropagator implements TextMapPropagator {
+	private readonly _jaegerTraceHeader;
+	private readonly _jaegerBaggageHeaderPrefix;
+	constructor(customTraceHeader?: string);
+	constructor(config?: JaegerPropagatorConfig);
+	inject(context: Context, carrier: unknown, setter: TextMapSetter): void;
+	extract(context: Context, carrier: unknown, getter: TextMapGetter): Context;
+	fields(): string[];
+}
+
+export { JaegerPropagator, UBER_BAGGAGE_HEADER_PREFIX, UBER_TRACE_ID_HEADER };

--- a/opentelemetry/propagator-jaeger.js
+++ b/opentelemetry/propagator-jaeger.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/// <reference types="./propagator-jaeger.d.ts" />
+
+import { trace, propagation, TraceFlags } from './api.js';
+import { isTracingSuppressed } from './core.js';
+
+const UBER_TRACE_ID_HEADER = 'uber-trace-id';
+const UBER_BAGGAGE_HEADER_PREFIX = 'uberctx';
+class JaegerPropagator {
+	constructor(config) {
+		if (typeof config === 'string') {
+			this._jaegerTraceHeader = config;
+			this._jaegerBaggageHeaderPrefix = UBER_BAGGAGE_HEADER_PREFIX;
+		}
+		else {
+			this._jaegerTraceHeader =
+				config?.customTraceHeader || UBER_TRACE_ID_HEADER;
+			this._jaegerBaggageHeaderPrefix =
+				config?.customBaggageHeaderPrefix || UBER_BAGGAGE_HEADER_PREFIX;
+		}
+	}
+	inject(context, carrier, setter) {
+		const spanContext = trace.getSpanContext(context);
+		const baggage = propagation.getBaggage(context);
+		if (spanContext && isTracingSuppressed(context) === false) {
+			const traceFlags = `0${(spanContext.traceFlags || TraceFlags.NONE).toString(16)}`;
+			setter.set(carrier, this._jaegerTraceHeader, `${spanContext.traceId}:${spanContext.spanId}:0:${traceFlags}`);
+		}
+		if (baggage) {
+			for (const [key, entry] of baggage.getAllEntries()) {
+				setter.set(carrier, `${this._jaegerBaggageHeaderPrefix}-${key}`, encodeURIComponent(entry.value));
+			}
+		}
+	}
+	extract(context, carrier, getter) {
+		const uberTraceIdHeader = getter.get(carrier, this._jaegerTraceHeader);
+		const uberTraceId = Array.isArray(uberTraceIdHeader)
+			? uberTraceIdHeader[0]
+			: uberTraceIdHeader;
+		const baggageValues = getter
+			.keys(carrier)
+			.filter(key => key.startsWith(`${this._jaegerBaggageHeaderPrefix}-`))
+			.map(key => {
+			const value = getter.get(carrier, key);
+			return {
+				key: key.substring(this._jaegerBaggageHeaderPrefix.length + 1),
+				value: Array.isArray(value) ? value[0] : value,
+			};
+		});
+		let newContext = context;
+		if (typeof uberTraceId === 'string') {
+			const spanContext = deserializeSpanContext(uberTraceId);
+			if (spanContext) {
+				newContext = trace.setSpanContext(newContext, spanContext);
+			}
+		}
+		if (baggageValues.length === 0)
+			return newContext;
+		let currentBaggage = propagation.getBaggage(context) ?? propagation.createBaggage();
+		for (const baggageEntry of baggageValues) {
+			if (baggageEntry.value === undefined)
+				continue;
+			currentBaggage = currentBaggage.setEntry(baggageEntry.key, {
+				value: decodeURIComponent(baggageEntry.value),
+			});
+		}
+		newContext = propagation.setBaggage(newContext, currentBaggage);
+		return newContext;
+	}
+	fields() {
+		return [this._jaegerTraceHeader];
+	}
+}
+const VALID_HEX_RE = /^[0-9a-f]{1,2}$/i;
+function deserializeSpanContext(serializedString) {
+	const headers = decodeURIComponent(serializedString).split(':');
+	if (headers.length !== 4) {
+		return null;
+	}
+	const [_traceId, _spanId, , flags] = headers;
+	const traceId = _traceId.padStart(32, '0');
+	const spanId = _spanId.padStart(16, '0');
+	const traceFlags = VALID_HEX_RE.test(flags) ? parseInt(flags, 16) & 1 : 1;
+	return { traceId, spanId, isRemote: true, traceFlags };
+}
+
+export { JaegerPropagator, UBER_BAGGAGE_HEADER_PREFIX, UBER_TRACE_ID_HEADER };

--- a/opentelemetry/sdk-logs.d.ts
+++ b/opentelemetry/sdk-logs.d.ts
@@ -16,7 +16,7 @@
 
 import { IResource } from './resources.d.ts';
 import * as logsAPI from './api-logs.d.ts';
-import { SeverityNumber, LogAttributes } from './api-logs.d.ts';
+import { SeverityNumber, LogAttributes, Logger } from './api-logs.d.ts';
 import * as api from './api.d.ts';
 import { HrTime, SpanContext, AttributeValue, Context } from './api.d.ts';
 import { InstrumentationScope, ExportResult } from './core.d.ts';
@@ -29,10 +29,6 @@ interface LoggerProviderConfig {
 	* The default value is 30000ms
 	*/
 	forceFlushTimeoutMillis?: number;
-	/** Log Record Limits*/
-	logRecordLimits?: LogRecordLimits;
-}
-interface LoggerConfig {
 	/** Log Record Limits*/
 	logRecordLimits?: LogRecordLimits;
 }
@@ -75,15 +71,14 @@ interface ReadableLogRecord {
 	readonly attributes: LogAttributes;
 }
 
-declare class Logger implements logsAPI.Logger {
-	readonly instrumentationScope: InstrumentationScope;
-	private _loggerProvider;
+declare class LoggerProviderSharedState {
 	readonly resource: IResource;
-	private readonly _loggerConfig;
-	constructor(instrumentationScope: InstrumentationScope, config: LoggerConfig, _loggerProvider: LoggerProvider);
-	emit(logRecord: logsAPI.LogRecord): void;
-	getLogRecordLimits(): LogRecordLimits;
-	getActiveLogRecordProcessor(): LogRecordProcessor;
+	readonly forceFlushTimeoutMillis: number;
+	readonly logRecordLimits: Required<LogRecordLimits>;
+	readonly loggers: Map<string, Logger>;
+	activeProcessor: LogRecordProcessor;
+	readonly registeredLogRecordProcessors: LogRecordProcessor[];
+	constructor(resource: IResource, forceFlushTimeoutMillis: number, logRecordLimits: Required<LogRecordLimits>);
 }
 
 declare class LogRecord implements ReadableLogRecord {
@@ -104,17 +99,18 @@ declare class LogRecord implements ReadableLogRecord {
 	get severityNumber(): logsAPI.SeverityNumber | undefined;
 	set body(body: string | undefined);
 	get body(): string | undefined;
-	constructor(logger: Logger, logRecord: logsAPI.LogRecord);
+	constructor(_sharedState: LoggerProviderSharedState, instrumentationScope: InstrumentationScope, logRecord: logsAPI.LogRecord);
 	setAttribute(key: string, value?: LogAttributes | AttributeValue): this;
 	setAttributes(attributes: LogAttributes): this;
 	setBody(body: string): this;
 	setSeverityNumber(severityNumber: logsAPI.SeverityNumber): this;
 	setSeverityText(severityText: string): this;
 	/**
+	* @internal
 	* A LogRecordProcessor may freely modify logRecord for the duration of the OnEmit call.
 	* If logRecord is needed after OnEmit returns (i.e. for asynchronous processing) only reads are permitted.
 	*/
-	makeReadonly(): void;
+	_makeReadonly(): void;
 	private _truncateToSize;
 	private _truncateToLimitUtil;
 	private _isLogRecordReadonly;
@@ -138,26 +134,9 @@ interface LogRecordProcessor {
 	shutdown(): Promise<void>;
 }
 
-/**
- * Implementation of the {@link LogRecordProcessor} that simply forwards all
- * received events to a list of {@link LogRecordProcessor}s.
- */
-declare class MultiLogRecordProcessor implements LogRecordProcessor {
-	readonly processors: LogRecordProcessor[];
-	readonly forceFlushTimeoutMillis: number;
-	constructor(processors: LogRecordProcessor[], forceFlushTimeoutMillis: number);
-	forceFlush(): Promise<void>;
-	onEmit(logRecord: LogRecord): void;
-	shutdown(): Promise<void>;
-}
-
 declare class LoggerProvider implements logsAPI.LoggerProvider {
-	readonly resource: IResource;
-	private readonly _loggers;
-	private _activeProcessor;
-	private readonly _registeredLogRecordProcessors;
-	private readonly _config;
 	private _shutdownOnce;
+	private readonly _sharedState;
 	constructor(config?: LoggerProviderConfig);
 	/**
 	* Get a logger with the configuration of the LoggerProvider.
@@ -181,14 +160,12 @@ declare class LoggerProvider implements logsAPI.LoggerProvider {
 	* Returns a promise which is resolved when all flushes are complete.
 	*/
 	shutdown(): Promise<void>;
-	getActiveLogRecordProcessor(): MultiLogRecordProcessor;
-	getActiveLoggers(): Map<string, Logger>;
 	private _shutdown;
 }
 
 declare class NoopLogRecordProcessor implements LogRecordProcessor {
 	forceFlush(): Promise<void>;
-	onEmit(_logRecord: ReadableLogRecord): void;
+	onEmit(_logRecord: ReadableLogRecord, _context: Context): void;
 	shutdown(): Promise<void>;
 }
 
@@ -291,4 +268,4 @@ declare class BatchLogRecordProcessor extends BatchLogRecordProcessorBase<Buffer
 	protected onShutdown(): void;
 }
 
-export { BatchLogRecordProcessor, BatchLogRecordProcessorBrowserConfig, BufferConfig, ConsoleLogRecordExporter, InMemoryLogRecordExporter, LogRecord, LogRecordExporter, LogRecordLimits, LogRecordProcessor, Logger, LoggerConfig, LoggerProvider, LoggerProviderConfig, NoopLogRecordProcessor, ReadableLogRecord, SimpleLogRecordProcessor };
+export { BatchLogRecordProcessor, BatchLogRecordProcessorBrowserConfig, BufferConfig, ConsoleLogRecordExporter, InMemoryLogRecordExporter, LogRecord, LogRecordExporter, LogRecordLimits, LogRecordProcessor, LoggerProvider, LoggerProviderConfig, NoopLogRecordProcessor, ReadableLogRecord, SimpleLogRecordProcessor };

--- a/opentelemetry/sdk-trace-base.d.ts
+++ b/opentelemetry/sdk-trace-base.d.ts
@@ -464,6 +464,7 @@ declare abstract class BatchSpanProcessorBase<T extends BufferConfig> implements
 	private readonly _maxQueueSize;
 	private readonly _scheduledDelayMillis;
 	private readonly _exportTimeoutMillis;
+	private _isExporting;
 	private _finishedSpans;
 	private _timer;
 	private _shutdownOnce;

--- a/otel-platform/otlp-json-exporters.ts
+++ b/otel-platform/otlp-json-exporters.ts
@@ -136,7 +136,10 @@ export class OTLPTracesExporter
   }
 
   convert(spans: ReadableSpan[]) {
-    return createExportTraceServiceRequest(spans, true);
+    return createExportTraceServiceRequest(spans, {
+      useHex: true,
+      useLongBits: false,
+    });
   }
 }
 
@@ -167,7 +170,10 @@ export class OTLPLogsExporter
   }
 
   convert(logs: ReadableLogRecord[]) {
-    return createExportLogsServiceRequest(logs, true);
+    return createExportLogsServiceRequest(logs, {
+      useHex: true,
+      useLongBits: false,
+    });
   }
 }
 // btw, events are event.name and event.domain

--- a/otel-platform/otlp-json-exporters.ts
+++ b/otel-platform/otlp-json-exporters.ts
@@ -79,11 +79,11 @@ abstract class OTLPFetchExporterBase<
   }
 
   onInit(): void {
-    window.addEventListener('unload', this.shutdown);
+    globalThis.addEventListener('unload', this.shutdown);
   }
 
   onShutdown(): void {
-    window.removeEventListener('unload', this.shutdown);
+    globalThis.removeEventListener('unload', this.shutdown);
   }
 
   send(


### PR DESCRIPTION
The upstream project reworked their monorepo configuration, so the generation script in this project had to be reworked as well.

Other than that, there are opentelemetry-js changes around the still-experimental Logs SDK, and improving int64 safety around timestamps and OTLP serialization.